### PR TITLE
Add support for environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,21 @@ Your amazon key, for access to S3.
 
 - __UNILOGINSECRET__
 Your unilogin secret, this must match whatever you use to authenticate.
+
+- __USE_ENV_CONFIG__
+This environment variable loads as much configuration from environment variables as possible. The following variables are required.
+
+- __DATABASE_HOST__
+The host running the Postgres database. 
+
+- __DATABASE_PORT__
+The port to use when connecting to the Postgres database.
+
+- __DATABASE_DB__
+The database to hold the application data.
+
+- __DATABASE_USER__
+The user to use when connecting to the database.
+
+- __DATABASE_PASSWORD__
+The password to use when connecting to the database.

--- a/server/datasources.development.js
+++ b/server/datasources.development.js
@@ -38,6 +38,38 @@ if (process.env.USE_DEFAULT_CONFIG) { // eslint-disable-line
     }
   };
 }
+else if (process.env.USE_ENV_CONFIG) { // eslint-disable-line
+  conf = {
+    db: {
+      name: 'db',
+      connector: 'memory'
+    },
+    psqlDs: {
+      host: process.env.DATABASE_HOST,
+      port: process.env.DATABASE_PORT,
+      database: process.env.DATABASE_DB,
+      username: process.env.DATABASE_USER,
+      password: process.env.DATABASE_PASSWORD,
+      name: 'psqlDs',
+      connector: 'postgresql'
+    },
+    emailDs: {
+      name: 'emailDs',
+      connector: 'mail',
+      transports: [
+        {
+          type: 'smtp',
+          host: 'mailhost.example.com',
+          secure: false,
+          port: 25,
+          tls: {
+            rejectUnauthorized: false
+          }
+        }
+      ]
+    }
+  };
+}
 else {
   conf = require('@dbcdk/biblo-config').communityservice.development;
 }


### PR DESCRIPTION
Currently the application only supports postgres running on the same host as the node application.

This change introduces a new environment variable `USE_ENV_CONFIG` which gets the database connection configuration from environment variables. This allows the database to run on any host - assuming the rest of the application also supports this.

This is also useful when running the application through Docker - see DBCDK/biblo-admin#2.

I do not think checking for a new environment variable `USE_ENV_CONFIG` and repeating the configuration structure again is very pretty. I considered adding the `DATABASE_*`environment variables to the `USE_DEFAULT_CONFIG` structure and using the current values as defaults but I could not find an elegant way to achieve this. I basicly ended up with very long lines of ternary operators a la

```
host: (process.env.DATABASE_HOST) ? host: process.env.DATABASE_HOST : '127.0.0.1' 
```
If you have other suggestions about how to achieve this let me know.