### PR TITLE
Update Swagger support to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "optionalDependencies": {
     "@dbcdk/biblo-config": "^1.3.1",
-    "loopback-explorer": "^1.1.0"
+    "loopback-component-explorer": "^2.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.6",

--- a/server/boot/explorer.js
+++ b/server/boot/explorer.js
@@ -3,26 +3,24 @@
 module.exports = function mountLoopBackExplorer(server) {
   var explorer;
   try {
-    explorer = require('loopback-explorer');
+    explorer = require('loopback-component-explorer');
   }
   catch (err) {
     // Print the message only when the app was started via `server.listen()`.
     // Do not print any message when the project is used as a component.
     server.once('started', function(baseUrl) { // eslint-disable-line no-unused-vars
-      console.log('Run `npm install loopback-explorer` to enable the LoopBack explorer'); // eslint-disable-line no-console
+      console.log('Run `npm install loopback-component-explorer` to enable the LoopBack component explorer'); // eslint-disable-line no-console
     });
     return;
   }
 
   var restApiRoot = server.get('restApiRoot');
 
-  var explorerApp = explorer(server, {basePath: restApiRoot});
+  var explorerApp = explorer.routes(server, {basePath: restApiRoot});
   server.use('/explorer', explorerApp);
   server.once('started', function() {
     var baseUrl = server.get('url').replace(/\/$/, '');
-    // express 4.x (loopback 2.x) uses `mountpath`
-    // express 3.x (loopback 1.x) uses `route`
-    var explorerPath = explorerApp.mountpath || explorerApp.route;
+    var explorerPath = '/explorer';
     console.log('Browse your REST API at %s%s', baseUrl, explorerPath); // eslint-disable-line no-console
   });
 };


### PR DESCRIPTION
swagger-codegen throws NullPointer exceptions when trying to parse the
Swagger 1.x output generated by loopback-explorer. This is probably
caused by Loopback generating an invalid swagger specification. It
refers to the invalid type “ref”.

To get Swagger 2.0 support we upgrade to loopback-component-explorer
2.3.0.

This requires a bit of updating in how it is mounted as well.