### PR TITLE
Rettelser til indeksering af review

### DIFF
--- a/common/mixins/searchable.js
+++ b/common/mixins/searchable.js
@@ -257,6 +257,10 @@ module.exports = function (Model, options) {
           }
         });
 
+        if (typeof Model.beforeIndex === 'function') {
+          Model.beforeIndex(instance, doc);
+        }
+
         return doc;
       }
 

--- a/common/mixins/searchable.js
+++ b/common/mixins/searchable.js
@@ -95,7 +95,7 @@ function loopbackToElasticDatatype(type) {
 module.exports = function (Model, options) {
   // Give the user an error if elastic is not enabled
   // Better to keep the API consistent across configurations.
-  Model.search = function (q, fields, limit, from, next) {
+  Model.search = function (q, fields, limit, from, sort, next) {
     next('Elastic search is not enabled! Please configure it!');
   };
 
@@ -472,13 +472,15 @@ module.exports = function (Model, options) {
      * @param {Array} fields - An array of fields we want to query on, in case we don't want to search the entire document.
      * @param {Number} limit - Limit is mostly used for pagination, to avoid excessive return sizes
      * @param {Number} from - From is an offset in items, also used for pagination.
+     * @param {Number} sort - field to sort on. ex: 'rating:asc'.
      * @param {function} next - callback from loopback.
      */
-    Model.search = function queryElastic(q, fields, limit, from, next) {
+    Model.search = function queryElastic(q, fields, limit, from, sort, next) {
       let params = {
         index,
         size: limit || 15,
-        from: from || 0
+        from: from || 0,
+        sort: sort
       };
 
       // If we have fields, we want to use a different query type
@@ -547,7 +549,8 @@ module.exports = function (Model, options) {
           description: 'Array of string containing fields to match on. Defaults to all fields.'
         },
         {arg: 'limit', type: 'number', required: false, description: 'How many items to retrieve. Default: 15'},
-        {arg: 'from', type: 'number', required: false, description: 'The starting index of hits to return. Default: 0'}
+        {arg: 'from', type: 'number', required: false, description: 'The starting index of hits to return. Default: 0'},
+        {arg: 'sort', type: 'string', required: false, description: 'Field to sort on. Ex: "rating:asc".'}
       ],
       returns: {
         arg: 'results', type: 'object', root: true

--- a/common/models/review.js
+++ b/common/models/review.js
@@ -7,7 +7,7 @@ module.exports = function(Review) {
     const NUM_LIKES_KEY = 'numLikes';
 
     // index number of likes, to be used for sorting
-    if(typeof instance.likes === 'function') {
+    if (typeof instance.likes === 'function') {
 
       // instance.likes is a loopback function, which
       // has to be invoked to collect actual values
@@ -18,10 +18,11 @@ module.exports = function(Review) {
 
       doc[NUM_LIKES_KEY] = numLikes;
 
-    } else {
+    }
+    else {
       doc[NUM_LIKES_KEY] = 0;
     }
-  }
+  };
 
   Review.afterSearch = function reviewAfterSearch (params, result) {
     if (
@@ -90,7 +91,7 @@ module.exports = function(Review) {
           // Remove the found title from titles array
           titles.splice(titles.indexOf(r.title), 1);
 
-          const promise = new Promise((resolve, reject) => {
+          const promise = new Promise(resolve => {
             r.reviews.add(review, () => {
               resolve();
             });
@@ -100,7 +101,7 @@ module.exports = function(Review) {
 
         // Rest of titles need to be first created then related to review
         titles.forEach(t => {
-          const promise = new Promise((resolve, reject) => {
+          const promise = new Promise(resolve => {
             model.create({title: t}, (createErr, createRes) => {
               if (!createErr) {
                 createRes.reviews.add(review, () => {

--- a/common/models/review.js
+++ b/common/models/review.js
@@ -1,6 +1,27 @@
 
+import {_} from 'lodash';
 
 module.exports = function(Review) {
+
+  Review.beforeIndex = function(instance, doc) {
+    const NUM_LIKES_KEY = 'numLikes';
+
+    // index number of likes, to be used for sorting
+    if(typeof instance.likes === 'function') {
+
+      // instance.likes is a loopback function, which
+      // has to be invoked to collect actual values
+      const likes = instance.likes();
+
+      // count unique profileId's across the list of likes
+      const numLikes = _.uniq(likes.map(like => like.profileId)).length;
+
+      doc[NUM_LIKES_KEY] = numLikes;
+
+    } else {
+      doc[NUM_LIKES_KEY] = 0;
+    }
+  }
 
   Review.afterSearch = function reviewAfterSearch (params, result) {
     if (

--- a/common/models/review.json
+++ b/common/models/review.json
@@ -26,7 +26,9 @@
         "image",
         "video",
         "likes",
-        "markedAsDeleted"
+        "markedAsDeleted",
+        "subjects",
+        "genres"
       ],
       "filter": {
         "include": [


### PR DESCRIPTION
Rettelser som understøtter anmeldelses-oversigt i biblo:
- subjects, genres indekseres til brug ved filtrering
- udvidelse til search endpoint, så man kan give en 'sort' param med
- antal likes indekseres i et felt for sig selv, så man nemt kan sortere på dette
